### PR TITLE
Fix pubkey validation

### DIFF
--- a/provisor/utils.py
+++ b/provisor/utils.py
@@ -47,9 +47,9 @@ def validate_pubkey(value):
       
     value = value.replace("\"", "").replace("'", "").replace("\\\"", "")
     value = value.split(' ')
-    if value[0] not in ('ssh-rsa','ssh-dsa','ecdsa-sha2-nistp256',
+    if value[0] not in ('ssh-rsa','ssh-dss','ecdsa-sha2-nistp256',
             'ecdsa-sha2-nistp384','ecdsa-sha2-nistp521','ssh-ed25519'):
-        raise ValueError("Expected 'ssh-rsa', 'ssh-dsa', 'ecdsa-sha2-nistp256',"
+        raise ValueError("Expected 'ssh-rsa', 'ssh-dss', 'ecdsa-sha2-nistp256',"
             " 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', or 'ssh-ed25519'")
     try:
         base64.decodestring(bytes(value[1]))

--- a/provisor/utils.py
+++ b/provisor/utils.py
@@ -42,8 +42,8 @@ def getch():
     return ch
 
 def validate_pubkey(value):
-    if len(value) > 8192:
-      raise ValueError("Length may not exceed 8192 characters")
+    if len(value) > 8192 or len(value) < 80:
+      raise ValueError("Expected length to be between 80 and 8192 characters")
       
     value = value.replace("\"", "").replace("'", "").replace("\\\"", "")
     value = value.split(' ')

--- a/provisor/utils.py
+++ b/provisor/utils.py
@@ -42,13 +42,15 @@ def getch():
     return ch
 
 def validate_pubkey(value):
-    if len(value) > 8192 or len(value) < 192:
-      raise ValueError("Expected length to be between 192 and 8192 characters")
+    if len(value) > 8192:
+      raise ValueError("Length may not exceed 8192 characters")
       
     value = value.replace("\"", "").replace("'", "").replace("\\\"", "")
     value = value.split(' ')
-    if value[0] not in ('ssh-rsa','ssh-dsa','ssh-ecdsa'):
-        raise ValueError("Expected 'ssh-rsa', 'ssh-dsa', or 'ssh-ecdsa'")
+    if value[0] not in ('ssh-rsa','ssh-dsa','ecdsa-sha2-nistp256',
+            'ecdsa-sha2-nistp384','ecdsa-sha2-nistp521','ssh-ed25519'):
+        raise ValueError("Expected 'ssh-rsa', 'ssh-dsa', 'ecdsa-sha2-nistp256',"
+            " 'ecdsa-sha2-nistp384', 'ecdsa-sha2-nistp521', or 'ssh-ed25519'")
     try:
         base64.decodestring(bytes(value[1]))
     except:


### PR DESCRIPTION
* Actually allow ECDSA keys on NIST curves (previously wrong identifier `ssh-ecdsa` was used instead of the three `ecdsa-sha2-nistp*`)
* Also allow Ed25519 keys while we're at it.
* Remove check for minimal length that filtered Ed25519 out (leave check for maximal length in place to prevent DoS as b34f452 intended when adding these checks).

It might fix #10.