### PR TITLE
Update utils.py

### DIFF
--- a/provisor/utils.py
+++ b/provisor/utils.py
@@ -48,7 +48,7 @@ def validate_pubkey(value):
     value = value.replace("\"", "").replace("'", "").replace("\\\"", "")
     value = value.split(' ')
     if value[0] not in ('ssh-rsa','ssh-dsa','ssh-ecdsa'):
-        raise ValueError("Expected 'ssh-rsa', 'ssh-dsa', or 'ssh-ecdsa'")
+        raise ValueError("Expected 'ssh-rsa', 'ssh-dss', or 'ssh-ecdsa'")
     try:
         base64.decodestring(bytes(value[1]))
     except:


### PR DESCRIPTION

Actually the DSA key is generated as "ssh-dss"
and this check returns true if the user choose DSA type.
Tested on FreeBSD, CentOS, Ubuntu.
The same is also applied for "ecdsa" but I'm not sure.