### PR TITLE
Fix the username validation

### DIFF
--- a/provisor/utils.py
+++ b/provisor/utils.py
@@ -71,7 +71,7 @@ def validate_username(value):
         'email','admin','admins','administrator','administrators','postmaster',
         'hostmaster','webmaster'
     ] 
-    if re.compile(r"^[a-zA-Z][a-zA-Z0-9_]{,30}$").match(value) is None:
+    if re.compile(r"^[a-z][a-z0-9]{,30}$").match(value) is None:
         raise ValueError('Username is invalid')
     if value in reserved_usernames:
         raise ValueError('Username is reserved')


### PR DESCRIPTION
The current version allows people to create users with capitalized letters, which breaks things (such as the mail delivery agent).